### PR TITLE
Add pytest for file_exists filter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Werkzeug>=2.0.1
 Jinja2>=3.0.1
 itsdangerous>=2.0.1
 click>=8.0.1
+pytest>=6.0
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,7 @@ This directory contains test scripts for the SyncedLyrics application.
 
 - `test_templates.py`: Tests the rendering of LRC and SRT debug templates (uses requests to test live server)
 - `test_routes.py`: Tests the Flask routes using the Flask test client
+- `test_filters.py`: Tests utility Jinja filters with pytest
 - `run_tests.py`: A test runner script that can run all tests or a specific test
 
 ## Running Tests

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,19 @@
+import os
+from app import file_exists_filter
+
+
+def test_file_exists_filter(tmp_path):
+    folder = tmp_path
+    # Create a non-empty file
+    existing = folder / "file.txt"
+    existing.write_text("hello")
+    assert file_exists_filter(existing.name, str(folder)) is True
+
+    # Create an empty file
+    empty = folder / "empty.txt"
+    empty.touch()
+    assert file_exists_filter(empty.name, str(folder)) is False
+
+    # Non-existent file
+    assert file_exists_filter("missing.txt", str(folder)) is False
+


### PR DESCRIPTION
## Summary
- test `file_exists_filter` using pytest
- document new test module in `tests/README.md`
- include `pytest` in `requirements.txt`

## Testing
- `pytest tests/test_filters.py -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857376a4d3483338239abddd10a00d3